### PR TITLE
Add extra error-handling to the file adapter

### DIFF
--- a/src/implementation/services/adapter.file-service.spec.ts
+++ b/src/implementation/services/adapter.file-service.spec.ts
@@ -54,6 +54,23 @@ describe('AdapterFileService', () => {
         expect(fileAdapter.createFileFromTemplate).not.toHaveBeenCalled();
     });
 
+    it('should throw an error if the file does exist', async () => {
+        fileAdapter.doesFileExist.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+
+        await expect(service.createFileWithTemplate('path/to/file', 'path/to/template')).rejects.toThrow('File already exists: path/to/file.md');
+
+        expect(fileAdapter.doesFileExist).toHaveBeenCalledWith('path/to/file.md');
+        expect(fileAdapter.doesFileExist).toHaveBeenCalledWith('path/to/template.md');
+        expect(fileAdapter.createFileFromTemplate).not.toHaveBeenCalled();
+    });
+
+    it('should throw an error when the adapter throws an error when creating a file', async () => {
+        fileAdapter.doesFileExist.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+        fileAdapter.createFileFromTemplate.mockRejectedValue(() => new Error('Error creating file'));
+
+        await expect(service.createFileWithTemplate('path/to/file', 'path/to/template')).rejects.toThrow('Error creating file: path/to/file.md');
+    });
+
     it('should open a file if it exists', async () => {
         fileAdapter.doesFileExist.mockResolvedValue(true);
 
@@ -70,5 +87,12 @@ describe('AdapterFileService', () => {
 
         expect(fileAdapter.doesFileExist).toHaveBeenCalledWith('path/to/file.md');
         expect(fileAdapter.openFile).not.toHaveBeenCalled();
+    });
+
+    it('should throw an error when the adapter throws an error when opening the file', async () => {
+        fileAdapter.doesFileExist.mockResolvedValue(true);
+        fileAdapter.openFile.mockRejectedValue(() => new Error('Error opening file'));
+
+        await expect(service.tryOpenFile('path/to/file')).rejects.toThrow('Error opening file: path/to/file.md');
     });
 });

--- a/src/implementation/services/adapter.file-service.ts
+++ b/src/implementation/services/adapter.file-service.ts
@@ -18,26 +18,34 @@ export class AdapterFileService implements FileService {
     public async createFileWithTemplate(filePath: string, templateFilePath: string): Promise<void> {
         const completeFilePath = filePath.appendMarkdownExtension()
         const completeTemplateFilePath = templateFilePath.appendMarkdownExtension()
-
         const fileExists = await this.doesFileExist(completeFilePath);
-        const templateFileExists = await this.fileAdapter.doesFileExist(completeTemplateFilePath);
+        const templateFileExists = await this.doesFileExist(completeTemplateFilePath);
 
-        if (!templateFileExists) {
+        if (fileExists) {
+            this.logger.logAndThrow(`File already exists: ${completeFilePath}`);
+        } else if (!templateFileExists) {
             this.logger.logAndThrow(`Template file does not exist: ${completeTemplateFilePath}`);
-        } else if (!fileExists) {
+        }
+
+        try {
             await this.fileAdapter.createFileFromTemplate(completeFilePath, completeTemplateFilePath);
+        } catch (_) {
+            this.logger.logAndThrow(`Error creating file: ${completeFilePath}`);
         }
     }
 
     public async tryOpenFile(filePath: string): Promise<void> {
         const completeFilePath = filePath.appendMarkdownExtension()
-
         const fileExists = await this.doesFileExist(completeFilePath);
 
         if (!fileExists) {
             this.logger.logAndThrow(`File does not exist: ${completeFilePath}`);
         }
 
-        await this.fileAdapter.openFile(completeFilePath);
+        try {
+            await this.fileAdapter.openFile(completeFilePath);
+        } catch (_) {
+            this.logger.logAndThrow(`Error opening file: ${completeFilePath}`);
+        }
     }
 }

--- a/src/plugin/adapters/obsidian.file-adapter.ts
+++ b/src/plugin/adapters/obsidian.file-adapter.ts
@@ -11,7 +11,7 @@ export class ObsidianFileAdapter implements FileAdapter {
 
     public async doesFileExist(filePath: string): Promise<boolean> {
         const normalizedPath = this.normalizePath(filePath);
-        return await this.vault.adapter.exists(normalizedPath, false);
+        return await this.vault.adapter.exists(normalizedPath, true);
     }
 
     public async createFileFromTemplate(filePath: string, templateFilePath: string): Promise<string> {


### PR DESCRIPTION
Display a message when the opening or creating of a file has caused an exception, as mentioned in #21.