### PR TITLE
Add listeners to update the notes below the calendar

### DIFF
--- a/src/daily-note-calendar.plugin.ts
+++ b/src/daily-note-calendar.plugin.ts
@@ -37,7 +37,7 @@ export default class DailyNoteCalendarPlugin extends Plugin {
         this.registerSettings();
         this.registerCommands();
 
-        this.app.workspace.onLayoutReady(this.registerPlugin.bind(this));
+        this.app.workspace.onLayoutReady(this.onLayoutReady.bind(this));
     }
 
     private async initializePlugin(): Promise<void> {
@@ -52,6 +52,14 @@ export default class DailyNoteCalendarPlugin extends Plugin {
         this.dependencies.monthlyNoteViewModel.updateSettings(settings);
         this.dependencies.quarterlyNoteViewModel.updateSettings(settings);
         this.dependencies.yearlyNoteViewModel.updateSettings(settings);
+    }
+
+    private onLayoutReady(): void {
+        this.registerPlugin();
+
+        this.app.vault.on('create', () => this.dependencies.notesViewModel.updateNotes?.call(this));
+        this.app.vault.on('delete', () => this.dependencies.notesViewModel.updateNotes?.call(this));
+        this.app.vault.on('rename', () => this.dependencies.notesViewModel.updateNotes?.call(this));
     }
 
     private registerPlugin(): void {

--- a/src/presentation/components/notes.component.tsx
+++ b/src/presentation/components/notes.component.tsx
@@ -12,11 +12,17 @@ export const NotesComponent = (props: NotesComponentProperties) => {
     const viewModel = useNotesViewModel();
     const [notes, setNotes] = React.useState<Note[]>([]);
 
-    React.useEffect(() => {
+    const loadNotes = () => {
         if (props.period) {
             viewModel?.loadNotes(props.period).then(setNotes);
         }
+    }
+
+    React.useEffect(() => {
+        loadNotes();
     }, [viewModel, setNotes, props.period]);
+
+    viewModel?.initializeCallbacks(loadNotes);
 
     return (
         <div className="dnc">

--- a/src/presentation/contracts/notes.view-model.ts
+++ b/src/presentation/contracts/notes.view-model.ts
@@ -2,6 +2,9 @@ import {Period} from 'src/domain/models/period.model';
 import {Note} from 'src/domain/models/note.model';
 
 export interface NotesViewModel {
+    updateNotes?: () => void;
+
+    initializeCallbacks(updateNotes: () => void): void;
     loadNotes(period: Period): Promise<Note[]>;
     openNoteInHorizontalSplitView(note: Note): Promise<void>
     openNoteInVerticalSplitView(note: Note): Promise<void>

--- a/src/presentation/settings/general/general.settings-view.ts
+++ b/src/presentation/settings/general/general.settings-view.ts
@@ -85,12 +85,13 @@ export class GeneralSettingsView extends SettingsView {
         const options = new Map<string, string>();
         options.set('iso', this.weekNumberStandardName(WeekNumberStandard.ISO));
         options.set('us', this.weekNumberStandardName(WeekNumberStandard.US));
+        const activeOption = options.keys().next(this.weekNumberStandardName(value)).value;
 
         this.addDropdownSetting(
             'Week number standard',
             'Set the week number standard for the calendar.',
             options,
-            this.weekNumberStandardName(value).toLowerCase(),
+            activeOption,
             async (value) => {
                 if (value.toLowerCase() === 'iso') {
                     return await onValueChange(WeekNumberStandard.ISO);

--- a/src/presentation/settings/settings-view.ts
+++ b/src/presentation/settings/settings-view.ts
@@ -67,6 +67,7 @@ export abstract class SettingsView {
                 .addOptions(Object.fromEntries(options))
                 .setValue(activeOption)
                 .onChange((value) => {
+                    console.log(value);
                     onChange(value).then(this.onSettingsChange);
                 })
             );

--- a/src/presentation/view-models/default.notes-view-model.spec.ts
+++ b/src/presentation/view-models/default.notes-view-model.spec.ts
@@ -29,6 +29,19 @@ describe('NotesViewModel', () => {
         jest.clearAllMocks();
     });
 
+    describe('initializeCallbacks', () => {
+        it('should set the callback functions', () => {
+            // Arrange
+            const updateNotes = jest.fn();
+
+            // Act
+            viewModel.initializeCallbacks(updateNotes);
+
+            // Assert
+            expect(viewModel.updateNotes).toEqual(updateNotes);
+        });
+    });
+
     describe('loadNotes', () => {
         it('should call the noteService and return the result', async () => {
             // Arrange

--- a/src/presentation/view-models/default.notes-view-model.ts
+++ b/src/presentation/view-models/default.notes-view-model.ts
@@ -4,10 +4,16 @@ import {NotesViewModel} from 'src/presentation/contracts/notes.view-model';
 import {NoteService} from 'src/presentation/contracts/note-service';
 
 export class DefaultNotesViewModel implements NotesViewModel {
+    public updateNotes?: () => void;
+
     constructor(
         private readonly noteService: NoteService
     ) {
 
+    }
+
+    public initializeCallbacks(updateNotes: () => void): void {
+        this.updateNotes = updateNotes;
     }
 
     public async loadNotes(period: Period): Promise<Note[]> {

--- a/src/test-helpers/view-model.mocks.ts
+++ b/src/test-helpers/view-model.mocks.ts
@@ -29,6 +29,9 @@ export const mockPeriodNoteViewModel = {
 } as jest.Mocked<PeriodNoteViewModel>;
 
 export const mockNotesViewModel = {
+    updateNotes: jest.fn(),
+
+    initializeCallbacks: jest.fn(),
     loadNotes: jest.fn(),
     openNote: jest.fn(),
     openNoteInHorizontalSplitView: jest.fn(),


### PR DESCRIPTION
Automatically update notes below the calendar when a new note is created or an existing note is modified or deleted.