### PR TITLE
Validate that a note exists before opening it

### DIFF
--- a/src/presentation/services/default.period-service.spec.ts
+++ b/src/presentation/services/default.period-service.spec.ts
@@ -5,6 +5,7 @@ import {GeneralSettings} from 'src/domain/settings/general.settings';
 import {Period, PeriodType} from 'src/domain/models/period.model';
 import {DEFAULT_DAILY_NOTE_SETTINGS} from 'src/domain/settings/period-note.settings';
 import {ModifierKey} from 'src/domain/models/modifier-key';
+import {when} from 'jest-when';
 
 describe('DefaultPeriodService', () => {
     const periodicNoteManager = mockPeriodicNoteManager;
@@ -44,7 +45,7 @@ describe('DefaultPeriodService', () => {
             expect(periodicNoteManager.openNote).toHaveBeenCalledWith(settings, period);
         });
 
-        it('should only call the openNote action if settings require a modifier key and the modifier key is not pressed', async () => {
+        it('should only call the openNote action if settings require a modifier key and the modifier key is not pressed if the note does not exist', async () => {
             // Arrange
             const key = ModifierKey.None;
             const settings = DEFAULT_DAILY_NOTE_SETTINGS;
@@ -53,6 +54,7 @@ describe('DefaultPeriodService', () => {
                     useModifierKeyToCreateNote: true
                 }
             };
+            when(periodicNoteManager.doesNoteExist).calledWith(settings, period).mockReturnValue(true);
 
             // Act
             await service.initialize(generalSettings);
@@ -63,7 +65,27 @@ describe('DefaultPeriodService', () => {
             expect(periodicNoteManager.openNote).toHaveBeenCalledWith(settings, period);
         });
 
-        it('should call the createNote and openNote action if the settings does not require a modifier key', async () => {
+        it('should not call the openNote action if settings require a modifier key and the modifier key is not pressed if the file exists', async () => {
+            // Arrange
+            const key = ModifierKey.None;
+            const settings = DEFAULT_DAILY_NOTE_SETTINGS;
+            const generalSettings = <PluginSettings> {
+                generalSettings: <GeneralSettings>{
+                    useModifierKeyToCreateNote: true
+                }
+            };
+            when(periodicNoteManager.doesNoteExist).calledWith(settings, period).mockReturnValue(false);
+
+            // Act
+            await service.initialize(generalSettings);
+            await service.openNoteInCurrentTab(key, period, settings);
+
+            // Assert
+            expect(periodicNoteManager.createNote).not.toHaveBeenCalled();
+            expect(periodicNoteManager.openNote).not.toHaveBeenCalled();
+        });
+
+        it('should call the createNote and openNote action if the settings does not require a modifier key if the note already exists', async () => {
             // Arrange
             const key = ModifierKey.None;
             const settings = DEFAULT_DAILY_NOTE_SETTINGS;
@@ -72,6 +94,27 @@ describe('DefaultPeriodService', () => {
                     useModifierKeyToCreateNote: false
                 }
             };
+            when(periodicNoteManager.doesNoteExist).calledWith(settings, period).mockReturnValue(true);
+
+            // Act
+            await service.initialize(generalSettings);
+            await service.openNoteInCurrentTab(key, period, settings);
+
+            // Assert
+            expect(periodicNoteManager.createNote).toHaveBeenCalledWith(settings, period);
+            expect(periodicNoteManager.openNote).toHaveBeenCalledWith(settings, period);
+        });
+
+        it('should call the createNote and openNote action if the settings does not require a modifier key if the note doesnt exist', async () => {
+            // Arrange
+            const key = ModifierKey.None;
+            const settings = DEFAULT_DAILY_NOTE_SETTINGS;
+            const generalSettings = <PluginSettings> {
+                generalSettings: <GeneralSettings>{
+                    useModifierKeyToCreateNote: false
+                }
+            };
+            when(periodicNoteManager.doesNoteExist).calledWith(settings, period).mockReturnValue(false);
 
             // Act
             await service.initialize(generalSettings);
@@ -107,7 +150,7 @@ describe('DefaultPeriodService', () => {
             expect(periodicNoteManager.openNoteInHorizontalSplitView).toHaveBeenCalledWith(settings, period);
         });
 
-        it('should only call the openNoteInHorizontalSplitView action if settings require a modifier key and the modifier key is not pressed', async () => {
+        it('should only call the openNoteInHorizontalSplitView action if settings require a modifier key and the modifier key is not pressed if the note exists', async () => {
             // Arrange
             const key = ModifierKey.None;
             const settings = DEFAULT_DAILY_NOTE_SETTINGS;
@@ -116,6 +159,7 @@ describe('DefaultPeriodService', () => {
                     useModifierKeyToCreateNote: true
                 }
             };
+            when(periodicNoteManager.doesNoteExist).calledWith(settings, period).mockReturnValue(true);
 
             // Act
             await service.initialize(generalSettings);
@@ -126,7 +170,27 @@ describe('DefaultPeriodService', () => {
             expect(periodicNoteManager.openNoteInHorizontalSplitView).toHaveBeenCalledWith(settings, period);
         });
 
-        it('should call the createNote and openNoteInHorizontalSplitView action if the settings does not require a modifier key', async () => {
+        it('should not call the openNoteInHorizontalSplitView action if settings require a modifier key and the modifier key is not pressed if the note does not exist', async () => {
+            // Arrange
+            const key = ModifierKey.None;
+            const settings = DEFAULT_DAILY_NOTE_SETTINGS;
+            const generalSettings = <PluginSettings> {
+                generalSettings: <GeneralSettings>{
+                    useModifierKeyToCreateNote: true
+                }
+            };
+            when(periodicNoteManager.doesNoteExist).calledWith(settings, period).mockReturnValue(false);
+
+            // Act
+            await service.initialize(generalSettings);
+            await service.openNoteInHorizontalSplitView(key, period, settings);
+
+            // Assert
+            expect(periodicNoteManager.createNote).not.toHaveBeenCalled();
+            expect(periodicNoteManager.openNoteInHorizontalSplitView).not.toHaveBeenCalled();
+        });
+
+        it('should call the createNote and openNoteInHorizontalSplitView action if the settings does not require a modifier key and the note already exists', async () => {
             // Arrange
             const key = ModifierKey.None;
             const settings = DEFAULT_DAILY_NOTE_SETTINGS;
@@ -135,6 +199,27 @@ describe('DefaultPeriodService', () => {
                     useModifierKeyToCreateNote: false
                 }
             };
+            when(periodicNoteManager.doesNoteExist).calledWith(settings, period).mockReturnValue(true);
+
+            // Act
+            await service.initialize(generalSettings);
+            await service.openNoteInHorizontalSplitView(key, period, settings);
+
+            // Assert
+            expect(periodicNoteManager.createNote).toHaveBeenCalledWith(settings, period);
+            expect(periodicNoteManager.openNoteInHorizontalSplitView).toHaveBeenCalledWith(settings, period);
+        });
+
+        it('should call the createNote and openNoteInHorizontalSplitView action if the settings does not require a modifier key if the note does not exist', async () => {
+            // Arrange
+            const key = ModifierKey.None;
+            const settings = DEFAULT_DAILY_NOTE_SETTINGS;
+            const generalSettings = <PluginSettings> {
+                generalSettings: <GeneralSettings>{
+                    useModifierKeyToCreateNote: false
+                }
+            };
+            when(periodicNoteManager.doesNoteExist).calledWith(settings, period).mockReturnValue(false);
 
             // Act
             await service.initialize(generalSettings);
@@ -170,7 +255,7 @@ describe('DefaultPeriodService', () => {
             expect(periodicNoteManager.openNoteInVerticalSplitView).toHaveBeenCalledWith(settings, period);
         });
 
-        it('should only call the openNoteInVerticalSplitView action if settings require a modifier key and the modifier key is not pressed', async () => {
+        it('should only call the openNoteInVerticalSplitView action if settings require a modifier key and the modifier key is not pressed if the note exists', async () => {
             // Arrange
             const key = ModifierKey.None;
             const settings = DEFAULT_DAILY_NOTE_SETTINGS;
@@ -179,6 +264,7 @@ describe('DefaultPeriodService', () => {
                     useModifierKeyToCreateNote: true
                 }
             };
+            when(periodicNoteManager.doesNoteExist).calledWith(settings, period).mockReturnValue(true);
 
             // Act
             await service.initialize(generalSettings);
@@ -189,7 +275,27 @@ describe('DefaultPeriodService', () => {
             expect(periodicNoteManager.openNoteInVerticalSplitView).toHaveBeenCalledWith(settings, period);
         });
 
-        it('should call the createNote and openNoteInVerticalSplitView action if the settings does not require a modifier key', async () => {
+        it('should not call the openNoteInVerticalSplitView action if settings require a modifier key and the modifier key is not pressed if the note does not exist', async () => {
+            // Arrange
+            const key = ModifierKey.None;
+            const settings = DEFAULT_DAILY_NOTE_SETTINGS;
+            const generalSettings = <PluginSettings> {
+                generalSettings: <GeneralSettings>{
+                    useModifierKeyToCreateNote: true
+                }
+            };
+            when(periodicNoteManager.doesNoteExist).calledWith(settings, period).mockReturnValue(false);
+
+            // Act
+            await service.initialize(generalSettings);
+            await service.openNoteInVerticalSplitView(key, period, settings);
+
+            // Assert
+            expect(periodicNoteManager.createNote).not.toHaveBeenCalled();
+            expect(periodicNoteManager.openNoteInVerticalSplitView).not.toHaveBeenCalled();
+        });
+
+        it('should call the createNote and openNoteInVerticalSplitView action if the settings does not require a modifier key if the note already exists', async () => {
             // Arrange
             const key = ModifierKey.None;
             const settings = DEFAULT_DAILY_NOTE_SETTINGS;
@@ -198,6 +304,27 @@ describe('DefaultPeriodService', () => {
                     useModifierKeyToCreateNote: false
                 }
             };
+            when(periodicNoteManager.doesNoteExist).calledWith(settings, period).mockReturnValue(true);
+
+            // Act
+            await service.initialize(generalSettings);
+            await service.openNoteInVerticalSplitView(key, period, settings);
+
+            // Assert
+            expect(periodicNoteManager.createNote).toHaveBeenCalledWith(settings, period);
+            expect(periodicNoteManager.openNoteInVerticalSplitView).toHaveBeenCalledWith(settings, period);
+        });
+
+        it('should call the createNote and openNoteInVerticalSplitView action if the settings does not require a modifier key if the note does not exist', async () => {
+            // Arrange
+            const key = ModifierKey.None;
+            const settings = DEFAULT_DAILY_NOTE_SETTINGS;
+            const generalSettings = <PluginSettings> {
+                generalSettings: <GeneralSettings>{
+                    useModifierKeyToCreateNote: false
+                }
+            };
+            when(periodicNoteManager.doesNoteExist).calledWith(settings, period).mockReturnValue(true);
 
             // Act
             await service.initialize(generalSettings);

--- a/src/presentation/services/default.period-service.spec.ts
+++ b/src/presentation/services/default.period-service.spec.ts
@@ -45,7 +45,7 @@ describe('DefaultPeriodService', () => {
             expect(periodicNoteManager.openNote).toHaveBeenCalledWith(settings, period);
         });
 
-        it('should only call the openNote action if settings require a modifier key and the modifier key is not pressed if the note does not exist', async () => {
+        it('should only call the openNote action if settings require a modifier key and the modifier key is not pressed if the note exists', async () => {
             // Arrange
             const key = ModifierKey.None;
             const settings = DEFAULT_DAILY_NOTE_SETTINGS;
@@ -65,7 +65,7 @@ describe('DefaultPeriodService', () => {
             expect(periodicNoteManager.openNote).toHaveBeenCalledWith(settings, period);
         });
 
-        it('should not call the openNote action if settings require a modifier key and the modifier key is not pressed if the file exists', async () => {
+        it('should not call the openNote action if settings require a modifier key and the modifier key is not pressed if the note does not exist', async () => {
             // Arrange
             const key = ModifierKey.None;
             const settings = DEFAULT_DAILY_NOTE_SETTINGS;
@@ -85,7 +85,7 @@ describe('DefaultPeriodService', () => {
             expect(periodicNoteManager.openNote).not.toHaveBeenCalled();
         });
 
-        it('should call the createNote and openNote action if the settings does not require a modifier key if the note already exists', async () => {
+        it('should call the createNote and openNote action if the settings do not require a modifier key if the note exists', async () => {
             // Arrange
             const key = ModifierKey.None;
             const settings = DEFAULT_DAILY_NOTE_SETTINGS;
@@ -105,7 +105,7 @@ describe('DefaultPeriodService', () => {
             expect(periodicNoteManager.openNote).toHaveBeenCalledWith(settings, period);
         });
 
-        it('should call the createNote and openNote action if the settings does not require a modifier key if the note doesnt exist', async () => {
+        it('should call the createNote and openNote action if the settings do not require a modifier key if the note doesnt exist', async () => {
             // Arrange
             const key = ModifierKey.None;
             const settings = DEFAULT_DAILY_NOTE_SETTINGS;
@@ -190,7 +190,7 @@ describe('DefaultPeriodService', () => {
             expect(periodicNoteManager.openNoteInHorizontalSplitView).not.toHaveBeenCalled();
         });
 
-        it('should call the createNote and openNoteInHorizontalSplitView action if the settings does not require a modifier key and the note already exists', async () => {
+        it('should call the createNote and openNoteInHorizontalSplitView action if the settings do not require a modifier key and the note already exists', async () => {
             // Arrange
             const key = ModifierKey.None;
             const settings = DEFAULT_DAILY_NOTE_SETTINGS;
@@ -210,7 +210,7 @@ describe('DefaultPeriodService', () => {
             expect(periodicNoteManager.openNoteInHorizontalSplitView).toHaveBeenCalledWith(settings, period);
         });
 
-        it('should call the createNote and openNoteInHorizontalSplitView action if the settings does not require a modifier key if the note does not exist', async () => {
+        it('should call the createNote and openNoteInHorizontalSplitView action if the settings do not require a modifier key if the note does not exist', async () => {
             // Arrange
             const key = ModifierKey.None;
             const settings = DEFAULT_DAILY_NOTE_SETTINGS;
@@ -295,7 +295,7 @@ describe('DefaultPeriodService', () => {
             expect(periodicNoteManager.openNoteInVerticalSplitView).not.toHaveBeenCalled();
         });
 
-        it('should call the createNote and openNoteInVerticalSplitView action if the settings does not require a modifier key if the note already exists', async () => {
+        it('should call the createNote and openNoteInVerticalSplitView action if the settings do not require a modifier key if the note exists', async () => {
             // Arrange
             const key = ModifierKey.None;
             const settings = DEFAULT_DAILY_NOTE_SETTINGS;
@@ -315,7 +315,7 @@ describe('DefaultPeriodService', () => {
             expect(periodicNoteManager.openNoteInVerticalSplitView).toHaveBeenCalledWith(settings, period);
         });
 
-        it('should call the createNote and openNoteInVerticalSplitView action if the settings does not require a modifier key if the note does not exist', async () => {
+        it('should call the createNote and openNoteInVerticalSplitView action if the settings do not require a modifier key if the note does not exist', async () => {
             // Arrange
             const key = ModifierKey.None;
             const settings = DEFAULT_DAILY_NOTE_SETTINGS;
@@ -324,7 +324,7 @@ describe('DefaultPeriodService', () => {
                     useModifierKeyToCreateNote: false
                 }
             };
-            when(periodicNoteManager.doesNoteExist).calledWith(settings, period).mockReturnValue(true);
+            when(periodicNoteManager.doesNoteExist).calledWith(settings, period).mockReturnValue(false);
 
             // Act
             await service.initialize(generalSettings);

--- a/src/presentation/services/default.period-service.spec.ts
+++ b/src/presentation/services/default.period-service.spec.ts
@@ -105,7 +105,7 @@ describe('DefaultPeriodService', () => {
             expect(periodicNoteManager.openNote).toHaveBeenCalledWith(settings, period);
         });
 
-        it('should call the createNote and openNote action if the settings do not require a modifier key if the note doesnt exist', async () => {
+        it('should call the createNote and openNote action if the settings do not require a modifier key if the note does not exist', async () => {
             // Arrange
             const key = ModifierKey.None;
             const settings = DEFAULT_DAILY_NOTE_SETTINGS;

--- a/src/presentation/services/default.period-service.ts
+++ b/src/presentation/services/default.period-service.ts
@@ -53,12 +53,16 @@ export class DefaultPeriodService implements PeriodService {
         const requireModifierKeyForCreatingNote = this.settings.generalSettings.useModifierKeyToCreateNote;
         const isModifierKeyPressed = requireModifierKeyForCreatingNote && isCreateFileModifierKey(key);
         const shouldCreateNote = !requireModifierKeyForCreatingNote || isModifierKeyPressed;
-        const doesNoteExist = await this.periodicNoteManager.doesNoteExist(settings, period);
 
         if (shouldCreateNote) {
             await this.periodicNoteManager.createNote(settings, period);
             await openAction(settings, period);
-        } else if (doesNoteExist) {
+
+            return;
+        }
+
+        const doesNoteExists = await this.periodicNoteManager.doesNoteExist(settings, period);
+        if (doesNoteExists) {
             await openAction(settings, period);
         }
     }

--- a/src/presentation/services/default.period-service.ts
+++ b/src/presentation/services/default.period-service.ts
@@ -53,11 +53,12 @@ export class DefaultPeriodService implements PeriodService {
         const requireModifierKeyForCreatingNote = this.settings.generalSettings.useModifierKeyToCreateNote;
         const isModifierKeyPressed = requireModifierKeyForCreatingNote && isCreateFileModifierKey(key);
         const shouldCreateNote = !requireModifierKeyForCreatingNote || isModifierKeyPressed;
+        const doesNoteExist = await this.periodicNoteManager.doesNoteExist(settings, period);
 
         if (shouldCreateNote) {
             await this.periodicNoteManager.createNote(settings, period);
             await openAction(settings, period);
-        } else {
+        } else if (doesNoteExist) {
             await openAction(settings, period);
         }
     }


### PR DESCRIPTION
When requiring a modifier key, it no longer shows an error if a periodic note does not exist when clicking in the calendar without the modifier key.